### PR TITLE
Enable `key` query string to embed API key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tilecloud/js",
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "tilecloud API",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tilecloud/js",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "tilecloud API",
   "main": "lib/index.js",
   "scripts": {

--- a/sample/index.html
+++ b/sample/index.html
@@ -30,7 +30,7 @@
   <div class="tilecloud" data-style="osm-bright" data-lat="35.681236" data-lng="139.767125" data-zoom="12"></div>
   <div class="place-holder">↓</div>
   <div class="tilecloud" data-style="dark-matter" data-lat="35.681236" data-lng="139.767125" data-zoom="12"></div>
-  <script src="./tilecloud.js?tilecloud=true&apiKey=anonymous"></script>
+  <script src="./tilecloud.js?tilecloud=true&key=anonymous"></script>
 </body>
 
 </html>

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -21,9 +21,10 @@ export default document => {
   const scripts = document.getElementsByTagName('script')
   for (const script of scripts) {
     const { query, host } = urlParse(script.src)
-    const { apiKey, tilecloud } = qs.parse(query.replace(/^\?/, ''))
+    const { key, apiKey, tilecloud } = qs.parse(query.replace(/^\?/, ''))
     if (tilecloud === 'true' || isKnownHost(host)) {
-      return apiKey
+      // backward compatibility for <= 0.2.3
+      return key || apiKey
     }
   }
 }

--- a/src/lib/parse-api-key.js
+++ b/src/lib/parse-api-key.js
@@ -23,7 +23,7 @@ export default document => {
     const { query, host } = urlParse(script.src)
     const { key, apiKey, tilecloud } = qs.parse(query.replace(/^\?/, ''))
     if (tilecloud === 'true' || isKnownHost(host)) {
-      // backward compatibility for <= 0.2.3
+      // backward compatibility for <= 0.2.2
       return key || apiKey
     }
   }

--- a/src/lib/parse-api-key.test.js
+++ b/src/lib/parse-api-key.test.js
@@ -26,6 +26,21 @@ describe('parse api key from dom', () => {
       }),
     )
   })
+
+  describe('known hosts with `key` parameter, not `apiKey`', () => {
+    const hosts = ['foo.tilecloud.io', 'tilecloud.github.io']
+
+    hosts.forEach(host =>
+      it(`should parse with known host ${host}`, () => {
+        const { document: mocDocument } = new JSDOM(`<html><body>
+          <script src="https://${host}/tilecloud.js?key=abc"></script>
+        </body></html>`).window
+
+        const apiKey = parseApiKey(mocDocument)
+        assert.equal(apiKey, 'abc')
+      }),
+    )
+  })
 })
 
 describe('not parse api key from dom', () => {


### PR DESCRIPTION
`<script src="./tilecloud.js?tilecloud=true&key=anonymous"></script>` will be acceptable in addition to `<script src="./tilecloud.js?tilecloud=true&apiKey=anonymous"></script>` with this change.
Fix for #6 .